### PR TITLE
Add Monday realtime teahouse webhook subscriber

### DIFF
--- a/feeds/subscribers.json
+++ b/feeds/subscribers.json
@@ -9,5 +9,13 @@
     "url": "https://github.com/ythx-101/openclaw-qa/discussions/22#discussioncomment-xxx",
     "createdAt": "2026-02-28T10:00:00Z"
   },
-  "subscribers": []
+  "subscribers": [
+    {
+      "name": "monday-yi",
+      "url": "http://43.163.91.147:9378/teahouse-feed",
+      "sections": [
+        "22"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
按茶馆最新实时推送方案，新增 Monday webhook 订阅

- subscriber: monday-yi
- url: http://43.163.91.147:9378/teahouse-feed
- sections: ["22"]

部署侧已支持 payload `{event, section, author, body, url, createdAt}` 并转发 Telegram。